### PR TITLE
Added support to aliases and subqueries on ansi joins

### DIFF
--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/DmlGrammar.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/DmlGrammar.java
@@ -110,12 +110,12 @@ public enum DmlGrammar implements GrammarRuleKey {
                         b.sequence(LPARENTHESIS, IDENTIFIER, b.zeroOrMore(COMMA, IDENTIFIER), RPARENTHESIS)));
         
         b.rule(INNER_CROSS_JOIN_CLAUSE).is(b.firstOf(
-                b.sequence(b.optional(INNER), JOIN, TABLE_REFERENCE, ON_OR_USING_EXPRESSION),
+                b.sequence(b.optional(INNER), JOIN, DML_TABLE_EXPRESSION_CLAUSE, ON_OR_USING_EXPRESSION),
                 b.sequence(
                         b.firstOf(
                                 CROSS,
                                 b.sequence(NATURAL, b.optional(INNER))),
-                        JOIN, TABLE_REFERENCE)
+                        JOIN, DML_TABLE_EXPRESSION_CLAUSE)
                 ));
         
         b.rule(OUTER_JOIN_CLAUSE).is(
@@ -123,10 +123,10 @@ public enum DmlGrammar implements GrammarRuleKey {
                 b.firstOf(
                         b.sequence(OUTER_JOIN_TYPE, JOIN),
                         b.sequence(NATURAL, b.optional(OUTER_JOIN_TYPE), JOIN)),
-                TABLE_REFERENCE, b.optional(QUERY_PARTITION_CLAUSE),
-                b.optional(ON_OR_USING_EXPRESSION));
+                b.sequence(DML_TABLE_EXPRESSION_CLAUSE, b.optional(QUERY_PARTITION_CLAUSE),
+                b.optional(ON_OR_USING_EXPRESSION)));
         
-        b.rule(JOIN_CLAUSE).is(TABLE_REFERENCE, b.oneOrMore(b.firstOf(INNER_CROSS_JOIN_CLAUSE, OUTER_JOIN_CLAUSE)));
+        b.rule(JOIN_CLAUSE).is(DML_TABLE_EXPRESSION_CLAUSE, b.oneOrMore(b.firstOf(INNER_CROSS_JOIN_CLAUSE, OUTER_JOIN_CLAUSE)));
         
         b.rule(SELECT_COLUMN).is(EXPRESSION, b.optional(b.optional(AS), IDENTIFIER_NAME));
         
@@ -135,7 +135,7 @@ public enum DmlGrammar implements GrammarRuleKey {
                         b.sequence(LPARENTHESIS, SELECT_EXPRESSION, RPARENTHESIS),
                         b.sequence(TABLE_REFERENCE, b.nextNot(LPARENTHESIS)),
                         OBJECT_REFERENCE),
-                b.optional(ALIAS));
+                b.optional(b.sequence(b.nextNot(b.firstOf(PARTITION, CROSS, USING, FULL, NATURAL, INNER, LEFT, RIGHT, OUTER, JOIN)), ALIAS )));
         
         b.rule(FROM_CLAUSE).is(
                 FROM, 

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/sql/JoinClauseTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/sql/JoinClauseTest.java
@@ -39,8 +39,18 @@ public class JoinClauseTest extends RuleTest {
     }
     
     @Test
+    public void matchesSimpleJoinWithTableAlias() {
+        assertThat(p).matches("foo f join bar b on f.a = b.a");
+    }
+    
+    @Test
     public void matchesInnerJoin() {
         assertThat(p).matches("foo inner join bar on foo.a = bar.a");
+    }
+    
+    @Test
+    public void matchesInnerJoinWithTableAlias() {
+        assertThat(p).matches("foo f inner join bar b on f.a = b.a");
     }
     
     @Test
@@ -49,8 +59,19 @@ public class JoinClauseTest extends RuleTest {
     }
     
     @Test
+    public void matchesJoinWithUsingWithTableAlias() {
+        assertThat(p).matches("foo f join bar b using (a)");
+    }
+    
+    
+    @Test
     public void matchesInnerJoinWithUsing() {
         assertThat(p).matches("foo inner join bar using (a)");
+    }
+    
+    @Test
+    public void matchesInnerJoinWithUsingWithTableAlias() {
+        assertThat(p).matches("foo f inner join bar n using (a)");
     }
     
     @Test
@@ -64,8 +85,18 @@ public class JoinClauseTest extends RuleTest {
     }
     
     @Test
+    public void matchesCrossJoinWithTableAlias() {
+        assertThat(p).matches("foo f cross join ba br");
+    }
+    
+    @Test
     public void matchesNaturalJoin() {
         assertThat(p).matches("foo natural join bar");
+    }
+    
+    @Test
+    public void matchesNaturalJoinWithTableAlias() {
+        assertThat(p).matches("foo f natural join bar b");
     }
     
     @Test
@@ -79,8 +110,18 @@ public class JoinClauseTest extends RuleTest {
     }
     
     @Test
+    public void matchesFullJoinWithTableAlias() {
+        assertThat(p).matches("foo f full join bar b on f.a = b.a");
+    }
+    
+    @Test
     public void matchesFullJoinWithUsing() {
         assertThat(p).matches("foo full join bar using (a)");
+    }
+    
+    @Test
+    public void matchesFullJoinWithUsingWithTableAlias() {
+        assertThat(p).matches("foo f full join bar b using (a)");
     }
     
     @Test
@@ -99,6 +140,11 @@ public class JoinClauseTest extends RuleTest {
     }
     
     @Test
+    public void matchesRightJoinWithTableAlias() {
+        assertThat(p).matches("foo f right join bar b on f.a = b.a");
+    }
+    
+    @Test
     public void matchesRightOuterJoin() {
         assertThat(p).matches("foo right outer join bar on foo.a = bar.a");
     }
@@ -106,6 +152,11 @@ public class JoinClauseTest extends RuleTest {
     @Test
     public void matchesLeftJoin() {
         assertThat(p).matches("foo left join bar on foo.a = bar.a");
+    }
+    
+    @Test
+    public void matchesLeftJoinWithTableAlias() {
+        assertThat(p).matches("foo f left join bar b on f.a = b.a");
     }
     
     @Test
@@ -151,5 +202,16 @@ public class JoinClauseTest extends RuleTest {
         assertThat(p).matches("foo left join bar partition by a, b on foo.a = bar.a");
         assertThat(p).matches("foo left join bar partition by (a, b) on foo.a = bar.a");
     }
-
+    
+    @Test
+    public void matchesJoinSubqueryWithTable() {
+        assertThat(p).matches("(select a from foo) f join bar b on f.a = b.a");
+    }
+    
+    @Test
+    public void matchesJoinTableWithSubquery() {
+        assertThat(p).matches("foo join (select a from bar) b on foo.a = b.a");
+    }
+    
+    
 }


### PR DESCRIPTION
- Changed DML_TABLE_EXPRESSION_CLAUSE to not match keywords as table alias (inner, left, outer, join, ...)
- Switched TABLE_REFERENCE to DML_TABLE_EXPRESSION_CLAUSE on JOIN_CLAUSE, OUTER_JOIN_CLAUSE and INNER_CROSS_JOIN_CLAUSE... in order to improve support for aliases, remote database tables and subqueries on ANSI JOINs
- Added unit tests to cover new test cases