### PR TITLE
Moved "AT" keyword from reserved to non reserved

### DIFF
--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/DdlGrammar.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/DdlGrammar.java
@@ -32,7 +32,12 @@ public enum DdlGrammar implements GrammarRuleKey {
     DDL_COMMAND,
     TABLE_COLUMN_DEFINITION,
     TABLE_RELATIONAL_PROPERTIES,
-    CREATE_TABLE;
+    CREATE_TABLE,
+    ALTER_PLSQL_UNIT,
+    ALTER_PROCEDURE_FUNCTION,
+    COMPILE_CLAUSE,
+    ALTER_TRIGGER,
+    ALTER_PACKAGE;
     
     public static void buildOn(LexerfulGrammarBuilder b) {
         createDdlCommands(b);
@@ -73,7 +78,31 @@ public enum DdlGrammar implements GrammarRuleKey {
                 b.optional(ON, COMMIT, b.firstOf(DELETE, PRESERVE), ROWS),
                 b.optional(SEMICOLON));
         
-        b.rule(DDL_COMMAND).is(b.firstOf(DDL_COMMENT, CREATE_TABLE));
+        b.rule(COMPILE_CLAUSE).is(COMPILE, b.optional(DEBUG), b.optional(REUSE, SETTINGS));
+        
+        b.rule(ALTER_TRIGGER).is(
+                TRIGGER, UNIT_NAME,
+                b.firstOf(ENABLE, 
+                          DISABLE, 
+                          b.sequence(RENAME, TO, IDENTIFIER_NAME), 
+                          COMPILE_CLAUSE)
+                );
+        
+        b.rule(ALTER_PROCEDURE_FUNCTION).is(
+                b.firstOf(PROCEDURE, FUNCTION)
+                , UNIT_NAME, COMPILE_CLAUSE
+                );
+        
+        b.rule(ALTER_PACKAGE).is(
+                PACKAGE, UNIT_NAME, COMPILE, 
+                b.optional(DEBUG), 
+                b.optional(b.firstOf(PACKAGE, SPECIFICATION, BODY)),
+                b.optional(REUSE, SETTINGS)
+                );
+        
+        b.rule(ALTER_PLSQL_UNIT).is(ALTER, b.firstOf(ALTER_TRIGGER, ALTER_PROCEDURE_FUNCTION, ALTER_PACKAGE), b.optional(SEMICOLON));
+        
+        b.rule(DDL_COMMAND).is(b.firstOf(DDL_COMMENT, CREATE_TABLE, ALTER_PLSQL_UNIT));
     }
 
 }

--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
@@ -37,6 +37,7 @@ public enum PlSqlKeyword implements TokenType {
     BY("by", true),
     CASE("case", true),
     CHECK("check", true),
+    COMPILE("compile", true),
     CLUSTERS("clusters", true),
     CLUSTER("cluster", true),
     COLAUTH("colauth", true),
@@ -87,6 +88,7 @@ public enum PlSqlKeyword implements TokenType {
     OVERLAPS("overlaps", true),
     PROCEDURE("procedure", true),
     PUBLIC("public", true),
+    RENAME("rename", true),
     RESOURCE("resource", true),
     REVOKE("revoke", true),
     SELECT("select", true),
@@ -327,7 +329,11 @@ public enum PlSqlKeyword implements TokenType {
     TRIM("trim"),
     LEADING("leading"),
     TRAILING("trailing"),
-    BOTH("both");
+    BOTH("both"),
+    DEBUG("debug"),
+    REUSE("reuse"),
+    SETTINGS("settings"),
+    SPECIFICATION("specification");
 
     private final String value;
     private final boolean reserved;

--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
@@ -37,7 +37,6 @@ public enum PlSqlKeyword implements TokenType {
     BY("by", true),
     CASE("case", true),
     CHECK("check", true),
-    COMPILE("compile", true),
     CLUSTERS("clusters", true),
     CLUSTER("cluster", true),
     COLAUTH("colauth", true),
@@ -88,7 +87,6 @@ public enum PlSqlKeyword implements TokenType {
     OVERLAPS("overlaps", true),
     PROCEDURE("procedure", true),
     PUBLIC("public", true),
-    RENAME("rename", true),
     RESOURCE("resource", true),
     REVOKE("revoke", true),
     SELECT("select", true),
@@ -125,6 +123,7 @@ public enum PlSqlKeyword implements TokenType {
     ARRAY("array"),
     ARROW("arrow"),
     AT("at"),
+    COMPILE("compile"),
     CURRENT("current"),
     DELETE("delete"),
     FORM("form"),
@@ -333,7 +332,8 @@ public enum PlSqlKeyword implements TokenType {
     DEBUG("debug"),
     REUSE("reuse"),
     SETTINGS("settings"),
-    SPECIFICATION("specification");
+    SPECIFICATION("specification"),
+    RENAME("rename");
 
     private final String value;
     private final boolean reserved;

--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
@@ -32,7 +32,6 @@ public enum PlSqlKeyword implements TokenType {
     ANY("any", true),
     AS("as", true),
     ASC("asc", true),
-    AT("at", true),
     BEGIN("begin", true),
     BETWEEN("between", true),
     BY("by", true),
@@ -123,6 +122,7 @@ public enum PlSqlKeyword implements TokenType {
     // non reserved keywords
     ARRAY("array"),
     ARROW("arrow"),
+    AT("at"),
     CURRENT("current"),
     DELETE("delete"),
     FORM("form"),

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/ddl/AlterPlsqlUnitTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/ddl/AlterPlsqlUnitTest.java
@@ -1,0 +1,100 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2016 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.ddl;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.DdlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class AlterPlsqlUnitTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(DdlGrammar.ALTER_PLSQL_UNIT);
+    }
+    
+    @Test
+    public void matchesAlterTriggerDisable() {
+        assertThat(p).matches("alter trigger foo disable;");
+    }
+    
+    @Test
+    public void matchesAlterTriggerEnable() {
+        assertThat(p).matches("alter trigger foo enable;");
+    }
+    
+    @Test
+    public void matchesAlterTriggerDisableWithSchema() {
+        assertThat(p).matches("alter trigger foo.bar disable;");
+    }
+    
+    @Test
+    public void matchesAlterTriggerDisableWithQuotedIdentifier() {
+        assertThat(p).matches("alter trigger \"foo\" rename to \"bar\";");
+    }
+    
+    @Test
+    public void matchesAlterTriggerCompile() {
+        assertThat(p).matches("alter trigger foo compile;");
+    }
+    
+    @Test
+    public void matchesAlterProcedureCompile() {
+        assertThat(p).matches("alter procedure foo compile;");
+    }
+    
+    @Test
+    public void matchesAlterFunctionCompile() {
+        assertThat(p).matches("alter function foo compile;");
+    }
+    
+    @Test
+    public void matchesAlterPackageCompile() {
+        assertThat(p).matches("alter package foo compile;");
+    }
+    
+    @Test
+    public void matchesAlterPackageCompileBody() {
+        assertThat(p).matches("alter package foo compile body;");
+    }
+    
+        @Test
+    public void matchesAlterPackageCompileBodyDebug() {
+        assertThat(p).matches("alter package foo compile debug body;");
+    }
+    
+    @Test
+    public void matchesAlterPackageCompilePackage() {
+        assertThat(p).matches("alter package foo compile package;");
+    }
+    
+    @Test
+    public void matchesAlterPackageCompileSpecification() {
+        assertThat(p).matches("alter package foo compile specification;");
+    }
+    
+    @Test
+    public void matchesAlterPackageCompileSpecificationReuseSettings() {
+        assertThat(p).matches("alter package foo compile debug specification reuse settings;");
+    }
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/ddl/AlterPlsqlUnitTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/ddl/AlterPlsqlUnitTest.java
@@ -78,7 +78,7 @@ public class AlterPlsqlUnitTest extends RuleTest {
         assertThat(p).matches("alter package foo compile body;");
     }
     
-        @Test
+    @Test
     public void matchesAlterPackageCompileBodyDebug() {
         assertThat(p).matches("alter package foo compile debug body;");
     }


### PR DESCRIPTION
The AT keyword is allowed to be used as a table alias on DML commands, so it is not a reserved keyword.