### PR TITLE
allow null value without format in ToDateWithoutFormatCheck

### DIFF
--- a/plsql-checks/src/main/java/org/sonar/plsqlopen/checks/ToDateWithoutFormatCheck.java
+++ b/plsql-checks/src/main/java/org/sonar/plsqlopen/checks/ToDateWithoutFormatCheck.java
@@ -21,10 +21,11 @@ package org.sonar.plsqlopen.checks;
 
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.plsqlopen.matchers.MethodMatcher;
-import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
 import org.sonar.plsqlopen.annnotations.ActivatedByDefault;
 import org.sonar.plsqlopen.annnotations.ConstantRemediation;
+import org.sonar.plsqlopen.matchers.MethodMatcher;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+
 import com.sonar.sslr.api.AstNode;
 
 @Rule(
@@ -47,8 +48,10 @@ public class ToDateWithoutFormatCheck extends AbstractBaseCheck {
         MethodMatcher toDate = MethodMatcher.create().name("to_date").addParameter();
         
         if (toDate.matches(node)) {
-            getContext().createViolation(this, getLocalizedMessage(CHECK_KEY), node);
+        	AstNode argument = toDate.getArguments(node).get(0).getLastChild();
+			if(!CheckUtils.isNullLiteralOrEmptyString(argument)) {
+				getContext().createViolation(this, getLocalizedMessage(CHECK_KEY), node);
+			}
         }
     }
-
 }

--- a/plsql-checks/src/test/resources/checks/to_date_without_format.sql
+++ b/plsql-checks/src/test/resources/checks/to_date_without_format.sql
@@ -1,7 +1,8 @@
 begin
   mydate := to_date('2015-01-01'); -- Noncompliant {{Specify the date format in this TO_DATE.}}
 --          ^^^^^^^^^^^^^^^^^^^^^
-  
+  to_date(null);
+  to_date('');
   mydate := to_date('2015-01-01', 'rrrr-mm-dd');
   mydate := my_to_date('2015-01-01');
   mydate := pkg.to_date('2015-01-01');


### PR DESCRIPTION
We use the 

> to_date(null)

 call to "cast" certain things to the date datatype (method calls or union's). In this cases the actual format does not matter.

If you don't want that behavior I would extract that to a custom rule on our side.