### PR TITLE
fixed result_cache and relies_on

### DIFF
--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.java
@@ -659,6 +659,7 @@ public enum PlSqlGrammar implements GrammarRuleKey {
                 FUNCTION, IDENTIFIER_NAME,
                 b.optional(LPARENTHESIS, b.oneOrMore(PARAMETER_DECLARATION, b.optional(COMMA)), RPARENTHESIS),
                 RETURN, DATATYPE, b.zeroOrMore(b.firstOf(DETERMINISTIC, PIPELINED)),
+                b.optional(RESULT_CACHE,b.optional(RELIES_ON,LPARENTHESIS,b.oneOrMore(OBJECT_REFERENCE,b.optional(COMMA)),RPARENTHESIS)),
                 b.optional(b.firstOf(
                         SEMICOLON,
                         b.sequence(b.firstOf(IS, AS), b.optional(DECLARE_SECTION), STATEMENTS_SECTION))
@@ -817,7 +818,8 @@ public enum PlSqlGrammar implements GrammarRuleKey {
                 CREATE, b.optional(OR, REPLACE),
                 FUNCTION, UNIT_NAME, b.optional(TIMESTAMP, STRING_LITERAL),
                 b.optional(LPARENTHESIS, b.oneOrMore(PARAMETER_DECLARATION, b.optional(COMMA)), RPARENTHESIS),
-                RETURN, DATATYPE, b.zeroOrMore(b.firstOf(DETERMINISTIC, PIPELINED, PARALLEL_ENABLE, RESULT_CACHE)),
+                RETURN, DATATYPE, b.zeroOrMore(b.firstOf(DETERMINISTIC, PIPELINED, PARALLEL_ENABLE)),
+                b.optional(RESULT_CACHE,b.optional(RELIES_ON,LPARENTHESIS,b.oneOrMore(OBJECT_REFERENCE,b.optional(COMMA)),RPARENTHESIS)),
                 b.optional(AUTHID, b.firstOf(CURRENT_USER, DEFINER)),
                 b.firstOf(
                         b.sequence(

--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
@@ -333,6 +333,7 @@ public enum PlSqlKeyword implements TokenType {
     VARYING("varying"),
     PARALLEL_ENABLE("parallel_enable"),
     RESULT_CACHE("result_cache"),
+    RELIES_ON("relies_on"),
     LISTAGG("listagg"),
     WITHIN("within"),
     ESCAPE("escape"),

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/units/CreateFunctionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/units/CreateFunctionTest.java
@@ -177,6 +177,15 @@ public class CreateFunctionTest extends RuleTest {
     }
     
     @Test
+    public void matchesResultCacheWithReliesOnFunction() {
+        assertThat(p).matches(""
+                + "create function test return number result_cache relies_on(tbl_test1, tbl_test2) is\n"
+                + "begin\n"
+                + "return 0;\n"
+                + "end;");
+    }
+    
+    @Test
     public void matchesFunctionWithTimestamp() {
         assertThat(p).matches(""
                 + "create function test timestamp '2015-01-01' return number is\n"

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/units/CreatePackageBodyTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/units/CreatePackageBodyTest.java
@@ -91,6 +91,17 @@ public class CreatePackageBodyTest extends RuleTest {
     }
     
     @Test
+    public void matchesPackageWithFunctionAndResultCache() {
+        assertThat(p).matches(""
+                + "create package body test is\n"
+                + "function func return number result_cache relies_on (tbl_test1,tbl_test2) is\n"
+                + "begin\n"
+                + "return null;\n"
+                + "end;\n"
+                + "end;");
+    }
+    
+    @Test
     public void matchesPackageWithFunctionAndCursor() {
     	assertThat(p).matches(""
     			+ "create package body test is\n"


### PR DESCRIPTION
Thanks for this project, I took a spin on this and it works smooth except few parsing errors in few of our source code.  First thing I found is the RESULT_CACHE and RELIES_ON keywords.   The changes done are,

- Added RELIES_ON keyword
- Changed the Grammar to include RESULT_CACHE and RELIES_ON for package body
- Corrected the existing RESULT_CACHE in standalone function to include RELIES_ON too
- Added unit test for these 2 

Now it parses pretty well to majority of our source
