### PR TITLE
Add row limiting clause for select statement

### DIFF
--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/DmlGrammar.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/DmlGrammar.java
@@ -305,9 +305,10 @@ public enum DmlGrammar implements GrammarRuleKey {
                             b.optional(HIERARCHICAL_QUERY_CLAUSE),
                             b.optional(b.firstOf(
                                     b.sequence(ORDER_BY_CLAUSE, b.optional(FOR_UPDATE_CLAUSE)),                                     
-                                    b.sequence(ORDER_BY_CLAUSE, b.optional(ROW_LIMITING_CLAUSE)), 
+                                    b.sequence(ORDER_BY_CLAUSE, b.optional(ROW_LIMITING_CLAUSE)),
+                                    ROW_LIMITING_CLAUSE,
                                     b.sequence(FOR_UPDATE_CLAUSE, b.optional(ORDER_BY_CLAUSE))))),
-                    b.sequence(LPARENTHESIS, SELECT_EXPRESSION, RPARENTHESIS, b.optional(ORDER_BY_CLAUSE, b.optional(ROW_LIMITING_CLAUSE)))),
+                    b.sequence(LPARENTHESIS, SELECT_EXPRESSION, RPARENTHESIS, b.optional(ORDER_BY_CLAUSE), b.optional(ROW_LIMITING_CLAUSE))),
                 b.optional(b.firstOf(MINUS_KEYWORD, INTERSECT, b.sequence(UNION, b.optional(ALL))), SELECT_EXPRESSION),
                 b.optional(FOR_UPDATE_CLAUSE));
     }

--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/DmlGrammar.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/DmlGrammar.java
@@ -304,8 +304,7 @@ public enum DmlGrammar implements GrammarRuleKey {
                             b.optional(HAVING_CLAUSE),
                             b.optional(HIERARCHICAL_QUERY_CLAUSE),
                             b.optional(b.firstOf(
-                                    b.sequence(ORDER_BY_CLAUSE, b.optional(FOR_UPDATE_CLAUSE)),                                     
-                                    b.sequence(ORDER_BY_CLAUSE, b.optional(ROW_LIMITING_CLAUSE)),
+                                    b.sequence(ORDER_BY_CLAUSE, b.optional(b.firstOf(FOR_UPDATE_CLAUSE, ROW_LIMITING_CLAUSE))),
                                     ROW_LIMITING_CLAUSE,
                                     b.sequence(FOR_UPDATE_CLAUSE, b.optional(ORDER_BY_CLAUSE))))),
                     b.sequence(LPARENTHESIS, SELECT_EXPRESSION, RPARENTHESIS, b.optional(ORDER_BY_CLAUSE), b.optional(ROW_LIMITING_CLAUSE))),

--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
@@ -392,8 +392,12 @@ public enum PlSqlKeyword implements TokenType {
     SESSION("session"),
     ROLE("role"),
     NONE("none"),
-    XMLAGG("xmlagg");
+    XMLAGG("xmlagg"),
+    OFFSET("offset"),
+    PERCENT("percent"),
+    TIES("ties");    
 
+    
     private final String value;
     private final boolean reserved;
 

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/sql/RowLimitingClauseTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/sql/RowLimitingClauseTest.java
@@ -1,0 +1,71 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.sql;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.DmlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class RowLimitingClauseTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(DmlGrammar.ROW_LIMITING_CLAUSE);
+    }
+    
+    @Test
+    public void matchesOffsetRow() {
+        assertThat(p).matches("offset 1 row");
+    }
+    
+    @Test
+    public void matchesOffsetRows() {
+        assertThat(p).matches("offset 1 rows");
+    }
+    
+    @Test
+    public void matchesOffsetAndFetchRowClause() {
+        assertThat(p).matches("offset 1 row fetch first 1 row only");
+    }
+    
+    @Test
+    public void matchesFetchFirstRowOnly() {
+        assertThat(p).matches("fetch first 1 row only");
+    }
+    
+    @Test
+    public void matchesFetchNextRowOnly() {
+        assertThat(p).matches("fetch next 1 row only");
+    }
+    
+    @Test
+    public void matchesFetchFirstRowWithTies() {
+        assertThat(p).matches("fetch first 1 row with ties");
+    }
+    
+    @Test
+    public void matchesFetchFirstPercentRowOnly() {
+        assertThat(p).matches("fetch first 1 percent row only");
+    }
+
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/sql/SelectExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/sql/SelectExpressionTest.java
@@ -173,4 +173,13 @@ public class SelectExpressionTest extends RuleTest {
         assertThat(p).matches("select 1 bulk bulk collect into var from dual");
     }
     
+    @Test
+    public void matchesSelectWithFetchFirstRowsOnly() {
+        assertThat(p).matches("select 1 from dual fetch first 1 row only");
+    }    
+    
+    @Test
+    public void matchesSelectWithOrderByAndFetchFirstRows() {
+        assertThat(p).matches("select 1 from dual order by 1 fetch first 1 row only");
+    }    
 }


### PR DESCRIPTION
Hello Felipe, I've just found your project and it's excellent piece of work. Unfortunately, I'm missing row limiting clause as described here
https://docs.oracle.com/database/121/SQLRF/statements_10002.htm#BABBADDD

So, I tried to implement it
- Added OFFSET, PERCENT, TIES keywords
- Added new clauses for SELECT expression - ROW_LIMITING_CLAUSE (composed from OFFSET_CLAUSE, FETCH_ROW_CLAUSE)
- Implemented ROW_LIMITING_CLAUSE into SELECT statement
- Added unit test for row limiting clause

Honestly, I'm using GIT for the first time, so just let me know, if there are any problems.

EDIT: I've found small error - row limiting clause could be used without order by clause.