### PR TITLE
Create trigger syntax fully implemented (#closes 56)

### DIFF
--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
@@ -392,7 +392,31 @@ public enum PlSqlKeyword implements TokenType {
     SESSION("session"),
     ROLE("role"),
     NONE("none"),
-    XMLAGG("xmlagg");
+    XMLAGG("xmlagg"),
+    COMPOUND("compound"),
+    INSTEAD("instead"),
+    STATEMENT_KEYWORD("statement"),
+    NESTED("nested"),
+    SCHEMA("schema"),
+    PLUGGABLE("pluggable"),
+    DATABASE("database"),
+    ANALYZE("analyze"),
+    ASSOCIATE("associate"),
+    DISASSOCIATE("disassociate"),
+    STATISTICS("statistics"),
+    AUDIT("audit"),
+    NOAUDIT("noaudit"),
+    TRUNCATE("truncate"),
+    DDL("ddl"),
+    STARTUP("startup"),
+    SHUTDOWN("shutdown"),
+    DB_ROLE_CHANGE("db_role_change"),
+    SERVERERROR("servererror"),
+    LOGON("logon"),
+    LOGOFF("logoff"),
+    SUSPEND("suspend"),
+    CLONE("clone"),
+    UNPLUG("unplug");
 
     private final String value;
     private final boolean reserved;

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/units/CreateTriggerTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/units/CreateTriggerTest.java
@@ -74,4 +74,45 @@ public class CreateTriggerTest extends RuleTest {
                 + "begin null; end;");
     }
     
+    @Test
+    public void matchesSystemDdlTrigger() {
+        assertThat(p).matches(""
+                + "create trigger foo "
+                + "before alter or analyze or associate statistics or audit or comment or create "
+                + "on foo.schema "
+                + "begin null; end;");
+    }  
+    
+    @Test
+    public void matchesSystemDatabaseTrigger() {
+        assertThat(p).matches(""
+                + "create trigger foo "
+                + "after startup or before logoff or after db_role_change "
+                + "on pluggable database "
+                + "begin null; end;");
+    }   
+    
+    @Test
+    public void matchesInsteadOfDmlTrigger() {
+        assertThat(p).matches(""
+                + "create trigger foo "
+                + "instead of insert or update on foo.bar "
+                + "for each row enable "
+                + "begin null; end;");
+    }   
+        
+    @Test
+    public void matchesCompoundDmlTrigger() {
+        assertThat(p).matches(""
+                + "create trigger foo "
+                + "for insert or update of bar on foo.bar "
+                + "compound trigger "
+                + "before each row is "
+                + "begin null; end before each row;"
+                + "after each row is "
+                + "begin null; end after each row;"
+                + "after statement is "
+                + "begin null; end after statement;"
+                + "end foo;");
+    }  
 }


### PR DESCRIPTION
Hello Felipe,
I tried to implement create trigger syntax as described here
https://docs.oracle.com/en/database/oracle/oracle-database/18/lnpls/CREATE-TRIGGER-statement.html#GUID-AF9E33F1-64D1-4382-A6A4-EC33C36F237B

Changes include:

- several new keywords
- implementation of instead of trigger, compound dml trigger and system trigger
- unit test cases for newly implemented triggers