### PR TITLE
Implementation of missing XML functions (fixes #59)

### DIFF
--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.java
@@ -177,6 +177,7 @@ public enum PlSqlKeyword implements TokenType {
     VARCHAR2("varchar2"),
     BOOLEAN("boolean"),
     DATE("date"),
+    XMLTYPE("xmltype"),
     ROWCOUNT("rowcount"),
     BULK_ROWCOUNT("bulk_rowcount"),
     COUNT("count"),
@@ -254,6 +255,7 @@ public enum PlSqlKeyword implements TokenType {
     ENCODING("encoding"),
     VERSION("version"),
     NO("no"),
+    YES("yes"),
     IDENT("ident"),
     HIDE("hide"),
     SHOW("show"),
@@ -272,6 +274,20 @@ public enum PlSqlKeyword implements TokenType {
     NAME("name"),
     EVALNAME("evalname"),
     XMLFOREST("xmlforest"),
+    XMLEXISTS("xmlexists"),
+    XMLQUERY("xmlquery"),
+    XMLROOT("xmlroot"),
+    XMLCAST("xmlcast"),
+    XMLCOLATTVAL("xmlcolattval"),
+    XMLPARSE("xmlparse"),
+    XMLPI("xmlpi"),
+    XMLTABLE("xmltable"),
+    XMLNAMESPACES("xmlnamespaces"),
+    STANDALONE("standalone"),
+    WELLFORMED("wellformed"),
+    PASSING("passing"),
+    ORDINALITY("ordinality"),
+    PATH("path"),
     JOIN("join"),
     ROWNUM("rownum"),
     LEVEL("level"),
@@ -419,7 +435,8 @@ public enum PlSqlKeyword implements TokenType {
     LOGOFF("logoff"),
     SUSPEND("suspend"),
     CLONE("clone"),
-    UNPLUG("unplug");
+    UNPLUG("unplug"),
+    VALUE("value");
 
     
     private final String value;

--- a/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/SingleRowSqlFunctionsGrammar.java
+++ b/plsql-frontend/src/main/java/org/sonar/plugins/plsqlopen/api/SingleRowSqlFunctionsGrammar.java
@@ -32,6 +32,11 @@ public enum SingleRowSqlFunctionsGrammar implements GrammarRuleKey {
 
     // internals
     XML_COLUMN,
+    XML_NAMESPACE,
+    XMLNAMESPACES_CLAUSE,
+    XMLTABLE_OPTIONS,
+    XML_PASSING_CLAUSE,
+    XML_TABLE_COLUMN,
     
     // functions
     EXTRACT_DATETIME_EXPRESSION,
@@ -40,6 +45,14 @@ public enum SingleRowSqlFunctionsGrammar implements GrammarRuleKey {
     XMLFOREST_EXPRESSION,
     XMLSERIALIZE_EXPRESSION,
     XMLAGG_EXPRESSION,
+    XMLEXISTS_EXPRESSION,
+    XMLQUERY_EXPRESSION,
+    XMLROOT_EXPRESSION,
+    XMLCAST_EXPRESSION,
+    XMLCOLATTVAL_EXPRESSION,
+    XMLPARSE_EXPRESSION,
+    XMLPI_EXPRESSION,
+    XMLTABLE_EXPRESSION,
     CAST_EXPRESSION,
     TRIM_EXPRESSION,
     SINGLE_ROW_SQL_FUNCTION;
@@ -57,6 +70,14 @@ public enum SingleRowSqlFunctionsGrammar implements GrammarRuleKey {
                 XMLFOREST_EXPRESSION,
                 XMLSERIALIZE_EXPRESSION,
                 XMLAGG_EXPRESSION,
+                XMLEXISTS_EXPRESSION,
+                XMLQUERY_EXPRESSION,
+                XMLROOT_EXPRESSION,
+                XMLCAST_EXPRESSION,
+                XMLCOLATTVAL_EXPRESSION,
+                XMLPARSE_EXPRESSION,
+                XMLPI_EXPRESSION,
+                XMLTABLE_EXPRESSION,
                 CAST_EXPRESSION,
                 TRIM_EXPRESSION)).skip();
     }
@@ -93,7 +114,7 @@ public enum SingleRowSqlFunctionsGrammar implements GrammarRuleKey {
         
         b.rule(XML_COLUMN).is(
                 EXPRESSION, b.optional(AS, b.firstOf(b.sequence(EVALNAME, EXPRESSION), IDENTIFIER_NAME)));
-        
+
         b.rule(XMLATTRIBUTES_EXPRESSION).is(
                 XMLATTRIBUTES, LPARENTHESIS,
                 b.optional(b.firstOf(ENTITYESCAPING, NOENTITYESCAPING)),
@@ -120,6 +141,84 @@ public enum SingleRowSqlFunctionsGrammar implements GrammarRuleKey {
         b.rule(XMLFOREST_EXPRESSION).is(
                 XMLFOREST, LPARENTHESIS,
                 XML_COLUMN, b.zeroOrMore(COMMA, XML_COLUMN),
+                RPARENTHESIS);
+        
+        b.rule(XML_PASSING_CLAUSE).is(
+                PASSING, b.optional(BY, VALUE),
+                IDENTIFIER_NAME, b.optional(AS, IDENTIFIER_NAME),
+                b.zeroOrMore(COMMA, IDENTIFIER_NAME, b.optional(AS, IDENTIFIER_NAME)));
+        
+        b.rule(XMLEXISTS_EXPRESSION).is(
+                XMLEXISTS, LPARENTHESIS, STRING_LITERAL,
+                b.optional(XML_PASSING_CLAUSE),
+                RPARENTHESIS);
+        
+        b.rule(XMLQUERY_EXPRESSION).is(
+                XMLQUERY, LPARENTHESIS, STRING_LITERAL,
+                b.optional(XML_PASSING_CLAUSE),
+                RETURNING, CONTENT,
+                b.optional(NULL, ON, EMPTY),
+                RPARENTHESIS);
+        
+        b.rule(XMLROOT_EXPRESSION).is(
+                XMLROOT, LPARENTHESIS,
+                EXPRESSION, COMMA,
+                VERSION, b.firstOf(b.sequence(NO, VALUE), EXPRESSION),
+                b.optional(COMMA, STANDALONE, b.firstOf(YES, b.sequence(NO, b.optional(VALUE)))),
+                RPARENTHESIS);
+        
+        b.rule(XMLCAST_EXPRESSION).is(
+                XMLCAST, LPARENTHESIS,
+                EXPRESSION, AS, DATATYPE,
+                RPARENTHESIS);
+        
+        b.rule(XMLCOLATTVAL_EXPRESSION).is(
+                XMLCOLATTVAL, LPARENTHESIS,
+                XML_COLUMN, b.zeroOrMore(COMMA, XML_COLUMN),
+                RPARENTHESIS);
+        
+        b.rule(XMLPARSE_EXPRESSION).is(
+                XMLPARSE, LPARENTHESIS,
+                b.firstOf(DOCUMENT, CONTENT), EXPRESSION, b.optional(WELLFORMED),
+                RPARENTHESIS);
+        
+        b.rule(XMLPI_EXPRESSION).is(
+                XMLPI, LPARENTHESIS,
+                b.firstOf(
+                        b.sequence(EVALNAME, EXPRESSION),
+                        b.sequence(b.optional(NAME), IDENTIFIER_NAME)),
+                b.optional(COMMA, EXPRESSION),
+                RPARENTHESIS);
+        
+        b.rule(XML_NAMESPACE).is(
+                b.firstOf(
+                        b.sequence(DEFAULT, STRING_LITERAL),
+                        b.sequence(STRING_LITERAL, AS, IDENTIFIER_NAME)));
+
+        b.rule(XMLNAMESPACES_CLAUSE).is(
+                XMLNAMESPACES, LPARENTHESIS,
+                XML_NAMESPACE, b.zeroOrMore(COMMA, XML_NAMESPACE),
+                RPARENTHESIS);
+        
+        b.rule(XML_TABLE_COLUMN).is(
+                IDENTIFIER_NAME,
+                b.firstOf(
+                        b.sequence(FOR, ORDINALITY),
+                        b.sequence(
+                                b.firstOf(
+                                        DATATYPE,
+                                        b.sequence(XMLTYPE, b.optional(LPARENTHESIS, SEQUENCE, RPARENTHESIS, BY, REF))),
+                                b.optional(PATH, STRING_LITERAL),
+                                b.optional(DEFAULT, STRING_LITERAL))));
+        
+        b.rule(XMLTABLE_OPTIONS).is(
+                b.optional(XML_PASSING_CLAUSE),
+                b.optional(RETURNING, SEQUENCE, BY, REF),
+                b.optional(COLUMNS, XML_TABLE_COLUMN, b.zeroOrMore(COMMA, XML_TABLE_COLUMN)));
+        
+        b.rule(XMLTABLE_EXPRESSION).is(
+                XMLTABLE, LPARENTHESIS,                
+                b.optional(XMLNAMESPACES_CLAUSE, COMMA), STRING_LITERAL, XMLTABLE_OPTIONS,
                 RPARENTHESIS);
     }
 

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlCastExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlCastExpressionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.expressions;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class XmlCastExpressionTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(PlSqlGrammar.EXPRESSION);
+    }
+    
+    @Test
+    public void matchesSimpleXmlCast() {
+        assertThat(p).matches("xmlcast(xmltype('<foo/>') as varchar2)");
+    }
+    
+    @Test
+    public void matchesXmlCastWithXmlQuery() {
+        assertThat(p).matches("xmlcast(xmlquery('<foo/>' passing bar returning content) as varchar2)");
+    }
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlColattvalExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlColattvalExpressionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.expressions;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class XmlColattvalExpressionTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(PlSqlGrammar.EXPRESSION);
+    }
+    
+    @Test
+    public void matchesSimpleXmlCollattval() {
+        assertThat(p).matches("xmlcolattval(foo, bar, foo2, bar2)");
+    }
+    
+    @Test
+    public void matchesXmlColattvalWithEvalname() {
+        assertThat(p).matches("xmlcolattval(foo as bar, foo as evalname bar)");
+    }   
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlExistsExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlExistsExpressionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.expressions;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class XmlExistsExpressionTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(PlSqlGrammar.EXPRESSION);
+    }
+    
+    @Test
+    public void matchesSimpleXmlExists() {
+        assertThat(p).matches("xmlexists('/foo')");
+    }
+    
+    @Test
+    public void matchesXmlExistsWithPassingClause() {
+        assertThat(p).matches("xmlexists('/foo' passing bar)");
+    }
+    
+    @Test
+    public void matchesXmlExistsWithPassingByValueClause() {
+        assertThat(p).matches("xmlexists('/foo' passing by value bar)");
+    }
+    
+     @Test
+    public void matchesXmlExistsWithPassingMoreValues() {
+        assertThat(p).matches("xmlexists('/foo' passing \"bar\" as bar, \"bar2\" as bar2)");
+    }
+    
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlParseExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlParseExpressionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.expressions;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class XmlParseExpressionTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(PlSqlGrammar.EXPRESSION);
+    }
+    
+    @Test
+    public void matchesSimpleXmlParse() {
+        assertThat(p).matches("xmlparse(content '<foo>bar</bar>')");
+    }
+    
+    @Test
+    public void matchesXmlParseDocument() {
+        assertThat(p).matches("xmlparse(document '<foo>bar</bar>')");
+    }
+    
+    @Test
+    public void matchesXmlParseDocumentWellformed() {
+        assertThat(p).matches("xmlparse(document '<foo>bar</bar>' wellformed)");
+    }
+    
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlPiExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlPiExpressionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.expressions;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class XmlPiExpressionTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(PlSqlGrammar.EXPRESSION);
+    }
+    
+    @Test
+    public void matchesSimpleXmlPi() {
+        assertThat(p).matches("xmlpi(name \"foo\")");
+    }
+    
+    @Test
+    public void matchesXmlPiWithEvalname() {
+        assertThat(p).matches("xmlpi(evalname foo)");
+    }
+    
+    @Test
+    public void matchesXmlPiWithContent() {
+        assertThat(p).matches("xmlpi(name \"foo\", 'bar')");
+    }
+    
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlQueryExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlQueryExpressionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.expressions;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class XmlQueryExpressionTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(PlSqlGrammar.EXPRESSION);
+    }
+    
+    @Test
+    public void matchesSimpleXmlQuery() {
+        assertThat(p).matches("xmlquery('/foo' returning content)");
+    }
+    
+    @Test
+    public void matchesXmlQueryWithNullOnEmpty() {
+        assertThat(p).matches("xmlquery('/foo' returning content null on empty)");
+    }
+    
+    @Test
+    public void matchesXmlQueryWithPassingByValueClause() {
+        assertThat(p).matches("xmlquery('/foo' passing by value bar returning content)");
+    }
+    
+     @Test
+    public void matchesXmlQueryWithPassingMoreValues() {
+        assertThat(p).matches("xmlquery('/foo' passing \"bar\" as bar, \"bar2\" as bar2 returning content)");
+    }
+    
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlRootExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlRootExpressionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.expressions;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class XmlRootExpressionTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(PlSqlGrammar.EXPRESSION);
+    }
+    
+    @Test
+    public void matchesSimpleXmlRoot() {
+        assertThat(p).matches("xmlroot(xmltype('<foo/>'), version no value)");
+    }
+    
+    @Test
+    public void matchesXmlRootWithVersion() {
+        assertThat(p).matches("xmlroot(xmltype('<foo/>'), version '1.0')");
+    }
+    
+    @Test
+    public void matchesXmlRootWithStandalone() {
+        assertThat(p).matches("xmlroot(xmltype('<foo/>'), version '1.0', standalone no value)");
+    }
+    
+}

--- a/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlTableExpressionTest.java
+++ b/plsql-frontend/src/test/java/org/sonar/plugins/plsqlopen/api/expressions/XmlTableExpressionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Sonar PL/SQL Plugin (Community)
+ * Copyright (C) 2015-2017 Felipe Zorzo
+ * mailto:felipebzorzo AT gmail DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.plsqlopen.api.expressions;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.plugins.plsqlopen.api.PlSqlGrammar;
+import org.sonar.plugins.plsqlopen.api.RuleTest;
+
+public class XmlTableExpressionTest extends RuleTest {
+
+    @Before
+    public void init() {
+        setRootRule(PlSqlGrammar.EXPRESSION);
+    }
+    
+    @Test
+    public void matchesSimpleXmlTable() {
+        assertThat(p).matches("xmltable('/foo' passing bar)");
+    }
+    
+    @Test
+    public void matchesXmlTableWithNamespaces() {
+        assertThat(p).matches("xmltable(xmlnamespaces ('foo' as bar, default 'foo2'), '/foo/bar:foo' passing bar)");
+    }
+    
+    @Test
+    public void matchesXmlTableReturningSequenceByRef() {
+        assertThat(p).matches("xmltable('/foo' passing bar returning sequence by ref)");
+    }    
+    @Test
+    public void matchesXmlTableWithColumns() {
+        assertThat(p).matches("xmltable('/foo' passing bar columns \"foo\" varchar2(1) path 'bar' default 'a', \"foo2\" varchar2(1) path 'bar2', \"foo3\" for ordinality)");
+    }
+    
+}


### PR DESCRIPTION
Hello Felipe,

I've just implemented missing XML functions, specifically
- XMLEXISTS
- XMLQUERY
- XMLROOT
- XMLCAST
- XMLCOLATTVAL
- XMLPARSE
- XMLPI
- XMLTABLE

Moreover, I added several new keywords and implemented test cases for all of XML functions above.

Please take a look and let me know, if there is something to change.
Thanks
Lubos